### PR TITLE
Updating url for api, due to SIRENE 3.09 version deprecation

### DIFF
--- a/src/api_insee/conf.py
+++ b/src/api_insee/conf.py
@@ -3,8 +3,8 @@ API_VERSION = {
     "url" : 'https://api.insee.fr',
 
     "path_token" : '/token',
-    "path_siren" : '/entreprises/sirene/V3/siren',
-    "path_siret" : '/entreprises/sirene/V3/siret',
-    "path_liens_succession" : '/entreprises/sirene/V3/siret/liensSuccession',
+    "path_siren" : '/entreprises/sirene/V3.11/siren',
+    "path_siret" : '/entreprises/sirene/V3.11/siret',
+    "path_liens_succession" : '/entreprises/sirene/V3.11/siret/liensSuccession',
 
 }


### PR DESCRIPTION
The INSEE SIRENE api base url changed after deprecation of version 3.09 on 6 of april